### PR TITLE
Refactor traceable to use a generic tracing info attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,22 @@ Or install it yourself as:
 
 ## Configuration
 
-Create an initializer to tell ActiveJob how to get current `actor_id` and `correlation_id` and how to set them once deserialized:
+Create an initializer to tell ActiveJob how to get current `tracing_info` and how to set it once deserialized:
 
 ```ruby
 # config/initializers/activejob_traceable.rb
 
-ActiveJob::Traceable.actor_id_getter = -> { CurrentScope.actor_id }
-ActiveJob::Traceable.actor_id_setter = ->(id) { CurrentScope.actor_id = id }
+ActiveJob::Traceable.tracing_info_getter = lambda do
+  {
+    actor_id: CurrentScope.actor_id,
+    correlation_id: CurrentScope.correlation_id
+  }
+end
 
-ActiveJob::Traceable.correlation_id_getter = -> { CurrentScope.correlation_id }
-ActiveJob::Traceable.correlation_id_setter = ->(id) { CurrentScope.correlation_id = id }
+ActiveJob::Traceable.tracing_info_setter = lambda do |attributes|
+  CurrentScope.actor_id = attributes[:actor_id]
+  CurrentScope.correlation_id = attributes[:correlation_id]
+end
 ```
 
 ## Usage

--- a/lib/activejob/traceable.rb
+++ b/lib/activejob/traceable.rb
@@ -13,40 +13,16 @@ module ActiveJob
   module Traceable
     module_function
 
-    def actor_id_setter=(lambda)
-      raise 'Actor ID setter should be callable' unless lambda.respond_to?(:call)
+    def tracing_info_getter=(lambda)
+      raise 'Tracing info getter should be callable' unless lambda.respond_to?(:call)
 
-      @actor_id_setter = lambda
+      @tracing_info_getter = lambda
     end
 
-    def actor_id_getter=(lambda)
-      raise 'Actor ID getter should be callable' unless lambda.respond_to?(:call)
+    def tracing_info_setter=(lambda)
+      raise 'Tracing info setter should be callable' unless lambda.respond_to?(:call)
 
-      @actor_id_getter = lambda
-    end
-
-    def correlation_id_setter=(lambda)
-      raise 'Correlation ID setter should be callable' unless lambda.respond_to?(:call)
-
-      @correlation_id_setter = lambda
-    end
-
-    def correlation_id_getter=(lambda)
-      raise 'Correlation ID getter should be callable' unless lambda.respond_to?(:call)
-
-      @correlation_id_getter = lambda
-    end
-
-    def trace_id_setter=(lambda)
-      raise 'Trace ID setter should be callable' unless lambda.respond_to?(:call)
-
-      @trace_id_setter = lambda
-    end
-
-    def trace_id_getter=(lambda)
-      raise 'Trace ID getter should be callable' unless lambda.respond_to?(:call)
-
-      @trace_id_getter = lambda
+      @tracing_info_setter = lambda
     end
   end
 end

--- a/lib/activejob/traceable/logging_patch.rb
+++ b/lib/activejob/traceable/logging_patch.rb
@@ -9,7 +9,9 @@ module ActiveJob
         private
 
         def tag_logger(*tags)
-          tags = append_custom_tags(tags)
+          if ActiveJob::Traceable.tracing_info_getter.respond_to?(:call)
+            tags << ActiveJob::Traceable.tracing_info_getter.call
+          end
 
           if logger.respond_to?(:tagged)
             tags.unshift 'ActiveJob' unless logger_tagged_by_active_job?
@@ -17,16 +19,6 @@ module ActiveJob
           else
             yield
           end
-        end
-
-        def append_custom_tags(tags)
-          traceable = ActiveJob::Traceable
-
-          tags << traceable.actor_id_getter.call if traceable.actor_id_getter.respond_to?(:call)
-          tags << traceable.correlation_id_getter.call if traceable.correlation_id_getter.respond_to?(:call)
-          tags << traceable.trace_id_getter.call if traceable.trace_id_getter.respond_to?(:call)
-
-          tags
         end
       end
     end

--- a/lib/activejob/traceable/traceable.rb
+++ b/lib/activejob/traceable/traceable.rb
@@ -5,40 +5,29 @@ module ActiveJob
     extend ActiveSupport::Concern
 
     included do
-      attr_accessor :actor_id, :correlation_id, :trace_id
+      attr_accessor :tracing_info
 
       def initialize(*arguments)
         super(*arguments)
 
-        @actor_id = Traceable.actor_id_getter.call if Traceable.actor_id_getter.respond_to?(:call)
-        @correlation_id = Traceable.correlation_id_getter.call if Traceable.correlation_id_getter.respond_to?(:call)
-        @trace_id = Traceable.trace_id_getter.call if Traceable.trace_id_getter.respond_to?(:call)
+        @tracing_info = Traceable.tracing_info_getter.call if Traceable.tracing_info_getter.respond_to?(:call)
       end
 
       def serialize
-        super.merge!(
-          actor_id: actor_id,
-          correlation_id: correlation_id,
-          trace_id: trace_id,
-        )
+        super.merge!(tracing_info: tracing_info)
       end
 
       def deserialize(job_data)
         super(job_data)
 
-        self.actor_id = job_data['actor_id']
-        self.correlation_id = job_data['correlation_id']
-        self.trace_id = job_data['trace_id']
+        self.tracing_info = job_data['tracing_info']
 
-        Traceable.actor_id_setter.call(actor_id) if Traceable.actor_id_setter.respond_to?(:call)
-        Traceable.correlation_id_setter.call(correlation_id) if Traceable.correlation_id_setter.respond_to?(:call)
-        Traceable.trace_id_setter.call(trace_id) if Traceable.trace_id_setter.respond_to?(:call)
+        Traceable.tracing_info_setter.call(tracing_info) if Traceable.tracing_info_setter.respond_to?(:call)
       end
     end
 
     class << self
-      attr_accessor :actor_id_getter, :correlation_id_getter, :trace_id_getter
-      attr_accessor :actor_id_setter, :correlation_id_setter, :trace_id_setter
+      attr_accessor :tracing_info_getter, :tracing_info_setter
     end
   end
 end

--- a/lib/activejob/traceable/version.rb
+++ b/lib/activejob/traceable/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveJob
   module Traceable
-    VERSION = '0.2.0'
+    VERSION = '0.3.0'
   end
 end


### PR DESCRIPTION
The goal of this PR is to use a generic `tracing_info` attribute so that any services can rely on.
With that change, a service can use his own tracing information fields without changing the contract with active_job_traceable gem.

Example:
Service A: `actor_id`, `correlation_id`
Service B: `trace_id`