### PR TITLE
Set tracing information hash values

### DIFF
--- a/lib/activejob/traceable.rb
+++ b/lib/activejob/traceable.rb
@@ -14,15 +14,26 @@ module ActiveJob
     module_function
 
     def tracing_info_getter=(lambda)
-      raise 'Tracing info getter should be callable' unless lambda.respond_to?(:call)
+      if lambda
+        raise 'Tracing info getter should be callable' unless lambda.respond_to?(:call)
+        raise 'Tracing info getter should contain a hash' unless lambda.call.is_a?(Hash)
 
-      @tracing_info_getter = lambda
+        @tracing_info_getter = lambda
+      else
+        # Resets the value
+        @tracing_info_getter = nil
+      end
     end
 
     def tracing_info_setter=(lambda)
-      raise 'Tracing info setter should be callable' unless lambda.respond_to?(:call)
+      if lambda
+        raise 'Tracing info setter should be callable' unless lambda.respond_to?(:call)
 
-      @tracing_info_setter = lambda
+        @tracing_info_setter = lambda
+      else
+        # Resets the value
+        @tracing_info_setter = nil
+      end
     end
   end
 end

--- a/lib/activejob/traceable/logging_patch.rb
+++ b/lib/activejob/traceable/logging_patch.rb
@@ -9,9 +9,8 @@ module ActiveJob
         private
 
         def tag_logger(*tags)
-          if ActiveJob::Traceable.tracing_info_getter.respond_to?(:call)
-            tags << ActiveJob::Traceable.tracing_info_getter.call
-          end
+          tags << ActiveJob::Traceable.tracing_info_getter.call.values.compact
+          tags.flatten!
 
           if logger.respond_to?(:tagged)
             tags.unshift 'ActiveJob' unless logger_tagged_by_active_job?

--- a/lib/activejob/traceable/traceable.rb
+++ b/lib/activejob/traceable/traceable.rb
@@ -10,7 +10,7 @@ module ActiveJob
       def initialize(*arguments)
         super(*arguments)
 
-        @tracing_info = Traceable.tracing_info_getter.call if Traceable.tracing_info_getter.respond_to?(:call)
+        @tracing_info = Traceable.tracing_info_getter.call
       end
 
       def serialize
@@ -20,14 +20,22 @@ module ActiveJob
       def deserialize(job_data)
         super(job_data)
 
-        self.tracing_info = job_data['tracing_info']
+        if job_data['tracing_info'].is_a?(Hash)
+          self.tracing_info = job_data['tracing_info']
+        end
 
-        Traceable.tracing_info_setter.call(tracing_info) if Traceable.tracing_info_setter.respond_to?(:call)
+        Traceable.tracing_info_setter.call(tracing_info)
       end
     end
 
     class << self
-      attr_accessor :tracing_info_getter, :tracing_info_setter
+      def tracing_info_getter
+        @tracing_info_getter || -> { {} }
+      end
+
+      def tracing_info_setter
+        @tracing_info_setter || -> {}
+      end
     end
   end
 end

--- a/lib/activejob/traceable/version.rb
+++ b/lib/activejob/traceable/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveJob
   module Traceable
-    VERSION = '0.3.1'
+    VERSION = '0.3.2'
   end
 end

--- a/spec/activejob/traceable_spec.rb
+++ b/spec/activejob/traceable_spec.rb
@@ -9,17 +9,49 @@ RSpec.describe 'ActiveJobTraceableJob', type: :job do
 
   class ActiveJobTraceableJob < ActiveJob::Base; end
 
-  before do
-    ActiveJob::Traceable.tracing_info_getter = lambda do
-      {
-        first_attribute: CurrentScope.first_attribute,
-        second_attribute: CurrentScope.second_attribute
-      }
+  describe '.tracing_info_getter=' do
+    context 'when it does not respond to :call' do
+      it 'raises an error' do
+        expect {
+          ActiveJob::Traceable.tracing_info_getter = 'getter'
+        }.to raise_error('Tracing info getter should be callable')
+      end
     end
 
-    ActiveJob::Traceable.tracing_info_setter = lambda do |attributes|
-      CurrentScope.first_attribute = attributes[:first_attribute]
-      CurrentScope.second_attribute = attributes[:second_attribute]
+    context 'when it does not contain a hash' do
+      it 'raises an error' do
+        expect {
+          ActiveJob::Traceable.tracing_info_getter = -> { 'getter' }
+        }.to raise_error('Tracing info getter should contain a hash')
+      end
+    end
+
+    context 'when it is callable and contains a hash' do
+      it 'assigns the variable' do
+        value = -> { { attribute: 'getter' } }
+        expect {
+          ActiveJob::Traceable.tracing_info_getter = value
+        }.to change(ActiveJob::Traceable, :tracing_info_getter).to(value)
+      end
+    end
+  end
+
+  describe '.tracing_info_setter=' do
+    context 'when it does not respond to :call' do
+      it 'raises an error' do
+        expect {
+          ActiveJob::Traceable.tracing_info_setter = 'setter'
+        }.to raise_error('Tracing info setter should be callable')
+      end
+    end
+
+    context 'when it is callable' do
+      it 'assigns the variable' do
+        value = -> { { attribute: 'setter' } }
+        expect {
+          ActiveJob::Traceable.tracing_info_setter = value
+        }.to change(ActiveJob::Traceable, :tracing_info_setter).to(value)
+      end
     end
   end
 
@@ -27,6 +59,18 @@ RSpec.describe 'ActiveJobTraceableJob', type: :job do
     subject(:job) { ActiveJobTraceableJob.perform_later }
 
     before do
+      ActiveJob::Traceable.tracing_info_getter = lambda do
+        {
+          first_attribute: CurrentScope.first_attribute,
+          second_attribute: CurrentScope.second_attribute
+        }
+      end
+
+      ActiveJob::Traceable.tracing_info_setter = lambda do |attributes|
+        CurrentScope.first_attribute = attributes[:first_attribute]
+        CurrentScope.second_attribute = attributes[:second_attribute]
+      end
+
       CurrentScope.first_attribute = 'first_attribute_value'
       CurrentScope.second_attribute = 'second_attribute_value'
     end
@@ -37,6 +81,13 @@ RSpec.describe 'ActiveJobTraceableJob', type: :job do
           first_attribute: 'first_attribute_value',
           second_attribute: 'second_attribute_value',
         )
+      end
+
+      context 'when tracing_info_getter is not set' do
+        it 'contains an empty hash' do
+          ActiveJob::Traceable.tracing_info_getter = nil
+          expect(job.tracing_info).to eq({})
+        end
       end
     end
 
@@ -110,7 +161,7 @@ RSpec.describe 'ActiveJobTraceableJob', type: :job do
       ActiveJobTraceableJob.perform_later
 
       expect(logger.messages).to include(
-        '{:first_attribute=>"first_attribute_value", :second_attribute=>"second_attribute_value"}',
+        "first_attribute_value", "second_attribute_value"
       )
     end
   end


### PR DESCRIPTION
Latest version had some issues because we were passing the entire `tracing_information` hash.
Now, we are passing values instead.